### PR TITLE
Replace short PHP tags

### DIFF
--- a/apply_for_room.php
+++ b/apply_for_room.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] . '/smis');
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_header_common.php');
 	define('RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] . '/hamis');
@@ -61,6 +61,6 @@ form{margin:0;padding:0 0 10px 0; border:1px dashed #ccc}fieldset{margin:1em 0;b
    ?>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/bookroom.php
+++ b/bookroom.php
@@ -280,7 +280,7 @@ echo '<style type="text/css">
 		?>
 	</div>
 </div>
-<?
+<?php
 function get_client_ip()
 {
 	$ipaddress = '';

--- a/bookroom05042011.php
+++ b/bookroom05042011.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</p></a></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/bookroom0908.php
+++ b/bookroom0908.php
@@ -253,7 +253,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/bookroom13042022.php
+++ b/bookroom13042022.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -194,6 +194,6 @@
 	?>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/bookroom2013_2014.php
+++ b/bookroom2013_2014.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == 'localhost' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		//define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] .'/smis');
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
@@ -238,7 +238,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/bookroom_22072015.php
+++ b/bookroom_22072015.php
@@ -251,7 +251,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/bookroom_orig.php
+++ b/bookroom_orig.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</a></p></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/bookroom_w.php
+++ b/bookroom_w.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</p></a></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/apply_for_room.php
+++ b/hamis-liveCopy/apply_for_room.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] . '/smis');
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_header_common.php');
 	define('RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] . '/hamis');
@@ -61,6 +61,6 @@ form{margin:0;padding:0 0 10px 0; border:1px dashed #ccc}fieldset{margin:1em 0;b
    ?>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/bookroom.php
+++ b/hamis-liveCopy/bookroom.php
@@ -268,7 +268,7 @@ echo '<style type="text/css">
         ?>
     </div>
 </div>
-<?
+<?php
 function get_client_ip()
 {
     $ipaddress = '';

--- a/hamis-liveCopy/bookroom05042011.php
+++ b/hamis-liveCopy/bookroom05042011.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</p></a></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/bookroom0908.php
+++ b/hamis-liveCopy/bookroom0908.php
@@ -253,7 +253,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/hamis-liveCopy/bookroom13042022.php
+++ b/hamis-liveCopy/bookroom13042022.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -194,6 +194,6 @@
 	?>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/bookroom2013_2014.php
+++ b/hamis-liveCopy/bookroom2013_2014.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == 'localhost' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		//define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT'] .'/smis');
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
@@ -238,7 +238,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/hamis-liveCopy/bookroom_22072015.php
+++ b/hamis-liveCopy/bookroom_22072015.php
@@ -251,7 +251,7 @@
 	?>
 	</div>
 </div>
-<?	
+<?php	
 	function get_client_ip() {
 		$ipaddress = '';
 		if (!empty($_SERVER['HTTP_CLIENT_IP']))

--- a/hamis-liveCopy/bookroom_orig.php
+++ b/hamis-liveCopy/bookroom_orig.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</a></p></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/bookroom_w.php
+++ b/hamis-liveCopy/bookroom_w.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	if($_SERVER["HTTP_HOST"] == '10.2.21.87' || $_SERVER["HTTP_HOST"]=='smis.uonbi.ac.ke'){
 		define('SMIS_RELATIVE_PATH', $_SERVER['DOCUMENT_ROOT']);
 		define('RELATIVE_PATH', SMIS_RELATIVE_PATH  . '/hamis');
@@ -92,6 +92,6 @@
     <div align="center"> For any correspondence on online room application write to <a href="mailto:hamis@uonbi.ac.ke">hamis@uonbi.ac.ke<a><br /> <br /><p align="center"><a href="terms_conditions.pdf" target="_blank">SWA Room Accomodation Terms and Conditions</p></a></div>
 	</div>
 </div>
-<?
+<?php
 	include_once(SMIS_RELATIVE_PATH .  '/includes/smis_footer.php');  
 ?>

--- a/hamis-liveCopy/zephyr/abstract/abstractdbinfo.abstract.php
+++ b/hamis-liveCopy/zephyr/abstract/abstractdbinfo.abstract.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * abstract database info
  * 

--- a/hamis-liveCopy/zephyr/functions/action_loader_functions.php
+++ b/hamis-liveCopy/zephyr/functions/action_loader_functions.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * helper routines to load actions. 
  * 

--- a/hamis-liveCopy/zephyr/functions/general_functions.php
+++ b/hamis-liveCopy/zephyr/functions/general_functions.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * load a db_domain model from current package context
  * 

--- a/hamis-liveCopy/zephyr/helper/DAO.php
+++ b/hamis-liveCopy/zephyr/helper/DAO.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Data Access Object which inserts, updates and deletes thru every possible model
  * 

--- a/hamis-liveCopy/zephyr/helper/DatabaseConnector.class.php
+++ b/hamis-liveCopy/zephyr/helper/DatabaseConnector.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Database connector, a singleton of adoDB
  * 

--- a/hamis-liveCopy/zephyr/helper/ZephyrException.class.php
+++ b/hamis-liveCopy/zephyr/helper/ZephyrException.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * customized exception object for zephyr
  * 

--- a/hamis-liveCopy/zephyr/helper/actionloader.class.php
+++ b/hamis-liveCopy/zephyr/helper/actionloader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * common actionloader class, loads actions
  * 

--- a/hamis-liveCopy/zephyr/helper/jsloader.class.php
+++ b/hamis-liveCopy/zephyr/helper/jsloader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * this class loads javascript files for a specific package
  * 

--- a/hamis-liveCopy/zephyr/helper/packagemanager.class.php
+++ b/hamis-liveCopy/zephyr/helper/packagemanager.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * packagemanager.class.php
  * this class loads all the package informations and defines the action path

--- a/hamis-liveCopy/zephyr/helper/phploader.class.php
+++ b/hamis-liveCopy/zephyr/helper/phploader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * this class loads php files from a specific package
  * 

--- a/hamis-liveCopy/zephyr/helper/zephyr.class.php
+++ b/hamis-liveCopy/zephyr/helper/zephyr.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * zephyr controller
  * 

--- a/hamis-liveCopy/zephyr/index.php
+++ b/hamis-liveCopy/zephyr/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * the startup page of zephyr
  * 

--- a/hamis-liveCopy/zephyr/interfaces/action.interface.php
+++ b/hamis-liveCopy/zephyr/interfaces/action.interface.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * action interface
  * 

--- a/hamis-liveCopy/zephyr/packages/calc/actions/add.class.php
+++ b/hamis-liveCopy/zephyr/packages/calc/actions/add.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class add implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/calc/actions/home.class.php
+++ b/hamis-liveCopy/zephyr/packages/calc/actions/home.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class home implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/action1.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/action1.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class action1 implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/action2.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/action2.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class action2 implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/aggregator.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/aggregator.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class aggregator implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/createdb.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/createdb.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class createdb implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/datainput.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/datainput.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class datainput implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/execute_script.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/execute_script.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class execute_script implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/image.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/image.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class image implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/index.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/index.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class index implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/process_output_filter.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/process_output_filter.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class process_output_filter implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/process_using_filter.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/process_using_filter.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class process_using_filter implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/processdata.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/processdata.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class processdata implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/report.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/report.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class report implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/sample_form.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/sample_form.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_form implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/sqlite_input.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/sqlite_input.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sqlite_input implements action
 {
 	public $params;

--- a/hamis-liveCopy/zephyr/packages/features/actions/sqlite_process.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/actions/sqlite_process.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 load_db_domain("student");
 class sqlite_process implements action
 {

--- a/hamis-liveCopy/zephyr/packages/features/db_domains/student.php
+++ b/hamis-liveCopy/zephyr/packages/features/db_domains/student.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class student
 {
 	public $name;

--- a/hamis-liveCopy/zephyr/packages/features/filters/sample_input.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/filters/sample_input.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_input
 {
 	public function process($params, $action)

--- a/hamis-liveCopy/zephyr/packages/features/filters/sample_output.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/filters/sample_output.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_output
 {
 	public function process($content, $action)

--- a/hamis-liveCopy/zephyr/packages/features/helper/dbinfo.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/helper/dbinfo.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class dbinfo extends abstractdbinfo
 {
 	public function __construct()

--- a/hamis-liveCopy/zephyr/packages/features/helper/initializer.class.php
+++ b/hamis-liveCopy/zephyr/packages/features/helper/initializer.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class initializer 
 {
 	public function initiate()

--- a/hamis-liveCopy/zephyr/packages/hello_world/actions/display_message.class.php
+++ b/hamis-liveCopy/zephyr/packages/hello_world/actions/display_message.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class display_message implements  action {
 	

--- a/hamis-liveCopy/zephyr/packages/student_db/actions/delete_student.class.php
+++ b/hamis-liveCopy/zephyr/packages/student_db/actions/delete_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/hamis-liveCopy/zephyr/packages/student_db/actions/insert_student.class.php
+++ b/hamis-liveCopy/zephyr/packages/student_db/actions/insert_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/hamis-liveCopy/zephyr/packages/student_db/actions/update_student.class.php
+++ b/hamis-liveCopy/zephyr/packages/student_db/actions/update_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/hamis-liveCopy/zephyr/packages/student_db/db_domains/std.php
+++ b/hamis-liveCopy/zephyr/packages/student_db/db_domains/std.php
@@ -1,4 +1,4 @@
-<? 
+<?php 
 class std {
 	public $roll;
 	public $name;

--- a/hamis-liveCopy/zephyr/packages/student_db/helper/dbinfo.class.php
+++ b/hamis-liveCopy/zephyr/packages/student_db/helper/dbinfo.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * dbinfo.class.php
  * this class exposes the information to loginto database relevant to this package

--- a/hamis-liveCopy/zephyr/packages/zephyr/actions/message.class.php
+++ b/hamis-liveCopy/zephyr/packages/zephyr/actions/message.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class message implements  action {
 	

--- a/hamis-liveCopy/zephyr/thirdparty/phplog/log_manager.class.php
+++ b/hamis-liveCopy/zephyr/thirdparty/phplog/log_manager.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * log_manager.class.php
  * logger singleton

--- a/hamis-liveCopy/zephyr/thirdparty/phplog/logger.class.php
+++ b/hamis-liveCopy/zephyr/thirdparty/phplog/logger.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * logger.class.php
  * logger object to log debug messages

--- a/hamis-liveCopy/zephyr/thirdparty/smarty/PHPDocument4.php
+++ b/hamis-liveCopy/zephyr/thirdparty/smarty/PHPDocument4.php
@@ -1,4 +1,4 @@
-<?
+<?php
 interface action
 {
 	function execute();

--- a/hamis-liveCopy/zephyr/thirdparty/smarty/smarty.php
+++ b/hamis-liveCopy/zephyr/thirdparty/smarty/smarty.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * smarty.class.php
  * smarty singleton

--- a/zephyr/abstract/abstractdbinfo.abstract.php
+++ b/zephyr/abstract/abstractdbinfo.abstract.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * abstract database info
  * 

--- a/zephyr/functions/action_loader_functions.php
+++ b/zephyr/functions/action_loader_functions.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * helper routines to load actions. 
  * 

--- a/zephyr/functions/general_functions.php
+++ b/zephyr/functions/general_functions.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * load a db_domain model from current package context
  * 

--- a/zephyr/helper/DAO.php
+++ b/zephyr/helper/DAO.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Data Access Object which inserts, updates and deletes thru every possible model
  * 

--- a/zephyr/helper/DatabaseConnector.class.php
+++ b/zephyr/helper/DatabaseConnector.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Database connector, a singleton of adoDB
  * 

--- a/zephyr/helper/ZephyrException.class.php
+++ b/zephyr/helper/ZephyrException.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * customized exception object for zephyr
  * 

--- a/zephyr/helper/actionloader.class.php
+++ b/zephyr/helper/actionloader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * common actionloader class, loads actions
  * 

--- a/zephyr/helper/jsloader.class.php
+++ b/zephyr/helper/jsloader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * this class loads javascript files for a specific package
  * 

--- a/zephyr/helper/packagemanager.class.php
+++ b/zephyr/helper/packagemanager.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * packagemanager.class.php
  * this class loads all the package informations and defines the action path

--- a/zephyr/helper/phploader.class.php
+++ b/zephyr/helper/phploader.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * this class loads php files from a specific package
  * 

--- a/zephyr/helper/zephyr.class.php
+++ b/zephyr/helper/zephyr.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * zephyr controller
  * 

--- a/zephyr/index.php
+++ b/zephyr/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * the startup page of zephyr
  * 

--- a/zephyr/interfaces/action.interface.php
+++ b/zephyr/interfaces/action.interface.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * action interface
  * 

--- a/zephyr/packages/calc/actions/add.class.php
+++ b/zephyr/packages/calc/actions/add.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class add implements action
 {
 	public $params;

--- a/zephyr/packages/calc/actions/home.class.php
+++ b/zephyr/packages/calc/actions/home.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class home implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/action1.class.php
+++ b/zephyr/packages/features/actions/action1.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class action1 implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/action2.class.php
+++ b/zephyr/packages/features/actions/action2.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class action2 implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/aggregator.class.php
+++ b/zephyr/packages/features/actions/aggregator.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class aggregator implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/createdb.class.php
+++ b/zephyr/packages/features/actions/createdb.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class createdb implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/datainput.class.php
+++ b/zephyr/packages/features/actions/datainput.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class datainput implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/execute_script.class.php
+++ b/zephyr/packages/features/actions/execute_script.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class execute_script implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/image.class.php
+++ b/zephyr/packages/features/actions/image.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class image implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/index.class.php
+++ b/zephyr/packages/features/actions/index.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class index implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/process_output_filter.class.php
+++ b/zephyr/packages/features/actions/process_output_filter.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class process_output_filter implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/process_using_filter.class.php
+++ b/zephyr/packages/features/actions/process_using_filter.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class process_using_filter implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/processdata.class.php
+++ b/zephyr/packages/features/actions/processdata.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class processdata implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/report.class.php
+++ b/zephyr/packages/features/actions/report.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class report implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/sample_form.class.php
+++ b/zephyr/packages/features/actions/sample_form.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_form implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/sqlite_input.class.php
+++ b/zephyr/packages/features/actions/sqlite_input.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sqlite_input implements action
 {
 	public $params;

--- a/zephyr/packages/features/actions/sqlite_process.class.php
+++ b/zephyr/packages/features/actions/sqlite_process.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 load_db_domain("student");
 class sqlite_process implements action
 {

--- a/zephyr/packages/features/db_domains/student.php
+++ b/zephyr/packages/features/db_domains/student.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class student
 {
 	public $name;

--- a/zephyr/packages/features/filters/sample_input.class.php
+++ b/zephyr/packages/features/filters/sample_input.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_input
 {
 	public function process($params, $action)

--- a/zephyr/packages/features/filters/sample_output.class.php
+++ b/zephyr/packages/features/filters/sample_output.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class sample_output
 {
 	public function process($content, $action)

--- a/zephyr/packages/features/helper/dbinfo.class.php
+++ b/zephyr/packages/features/helper/dbinfo.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class dbinfo extends abstractdbinfo
 {
 	public function __construct()

--- a/zephyr/packages/features/helper/initializer.class.php
+++ b/zephyr/packages/features/helper/initializer.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class initializer 
 {
 	public function initiate()

--- a/zephyr/packages/hello_world/actions/display_message.class.php
+++ b/zephyr/packages/hello_world/actions/display_message.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class display_message implements  action {
 	

--- a/zephyr/packages/student_db/actions/delete_student.class.php
+++ b/zephyr/packages/student_db/actions/delete_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/zephyr/packages/student_db/actions/insert_student.class.php
+++ b/zephyr/packages/student_db/actions/insert_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/zephyr/packages/student_db/actions/update_student.class.php
+++ b/zephyr/packages/student_db/actions/update_student.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * verifystd.class.php
  * auto generated code for zephyr using 'generator' version 2.00

--- a/zephyr/packages/student_db/db_domains/std.php
+++ b/zephyr/packages/student_db/db_domains/std.php
@@ -1,4 +1,4 @@
-<? 
+<?php 
 class std {
 	public $roll;
 	public $name;

--- a/zephyr/packages/student_db/helper/dbinfo.class.php
+++ b/zephyr/packages/student_db/helper/dbinfo.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * dbinfo.class.php
  * this class exposes the information to loginto database relevant to this package

--- a/zephyr/packages/zephyr/actions/message.class.php
+++ b/zephyr/packages/zephyr/actions/message.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class message implements  action {
 	

--- a/zephyr/thirdparty/phplog/log_manager.class.php
+++ b/zephyr/thirdparty/phplog/log_manager.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * log_manager.class.php
  * logger singleton

--- a/zephyr/thirdparty/phplog/logger.class.php
+++ b/zephyr/thirdparty/phplog/logger.class.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * logger.class.php
  * logger object to log debug messages

--- a/zephyr/thirdparty/smarty/PHPDocument4.php
+++ b/zephyr/thirdparty/smarty/PHPDocument4.php
@@ -1,4 +1,4 @@
-<?
+<?php
 interface action
 {
 	function execute();

--- a/zephyr/thirdparty/smarty/smarty.php
+++ b/zephyr/thirdparty/smarty/smarty.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * smarty.class.php
  * smarty singleton


### PR DESCRIPTION
## Summary
- update all PHP files to use `<?php` full tags instead of `<?`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c30075710832984810da6ede6a47a